### PR TITLE
used renamed header, fixed build

### DIFF
--- a/src/app/mainwindow.ui
+++ b/src/app/mainwindow.ui
@@ -749,7 +749,7 @@
   <customwidget>
    <class>MarkdownEditor</class>
    <extends>QPlainTextEdit</extends>
-   <header>markdowneditor.h</header>
+   <header>markdown_editor.h</header>
   </customwidget>
   <customwidget>
    <class>FindReplaceWidget</class>


### PR DESCRIPTION
fixed build error:
```
In file included from ../../../CuteMarkEd-ch/src/app/mainwindow.cpp:18:
./ui_mainwindow.h:32:10: fatal error: 'markdowneditor.h' file not found
#include "markdowneditor.h"
         ^
1 error generated.
make[1]: *** [mainwindow.o] Error 1
make: *** [sub-app-make_first] Error 2
11:57:51: The process "/usr/bin/make" exited with code 2.
Error while building/deploying project CuteMarkEd (kit: Desktop Qt 5.6.3 clang 64bit)
When executing step "Make"
```