### PR TITLE
fixed/updated/cleaned project files

### DIFF
--- a/src/app-static/app-static.pro
+++ b/src/app-static/app-static.pro
@@ -8,7 +8,7 @@ TARGET = app-static
 TEMPLATE = lib
 
 QT += gui
-lessThan(QT_VERSION, 5.6) {
+qtHaveModule(webkitwidgets) {
     QT += webkitwidgets
     DEFINES += WITH_QTWEBENGINE=0
 } else {

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -9,10 +9,9 @@ TEMPLATE = app
 
 include(../global.pri)
 
-QT += core gui printsupport
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT += core gui printsupport widgets
 win32: QT += winextras
-lessThan(QT_VERSION, 5.6) {
+qtHaveModule(webkitwidgets) {
     QT += webkitwidgets
     DEFINES += WITH_QTWEBENGINE=0
 } else {

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -9,7 +9,8 @@ TEMPLATE = app
 
 include(../global.pri)
 
-QT += core gui printsupport widgets
+QT += core gui printsupport
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 win32: QT += winextras
 qtHaveModule(webkitwidgets) {
     QT += webkitwidgets

--- a/src/libs/discount/discount.pro
+++ b/src/libs/discount/discount.pro
@@ -49,5 +49,3 @@ HEADERS += \
     config.h \
     config_win.h \
     config_mac.h
-
-macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/libs/discount/discount.pro
+++ b/src/libs/discount/discount.pro
@@ -8,7 +8,7 @@
 TARGET = discount
 TEMPLATE = lib
 
-QT       -= core gui
+CONFIG -= qt
 
 # compile output is unreadable with -Wall
 CONFIG += warn_off
@@ -49,3 +49,5 @@ HEADERS += \
     config.h \
     config_win.h \
     config_mac.h
+
+macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/libs/hoedown/hoedown.pro
+++ b/src/libs/hoedown/hoedown.pro
@@ -7,9 +7,12 @@
 TARGET = hoedown
 TEMPLATE = lib
 
-QT -= core gui
+CONFIG -= qt
 
-SRC_ROOT = $$PWD/../../../3rdparty/hoedown
+# compile output is unreadable with -Wall
+CONFIG += warn_off
+
+SRC_ROOT = $$PWD/../../../3rdparty/hoedown.git
 
 DEF_FILE = $${SRC_ROOT}/hoedown.def
 
@@ -18,3 +21,5 @@ SOURCES += \
 
 HEADERS += \
     $$files($${SRC_ROOT}/src/*.h)
+
+macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/libs/hoedown/hoedown.pro
+++ b/src/libs/hoedown/hoedown.pro
@@ -21,5 +21,3 @@ SOURCES += \
 
 HEADERS += \
     $$files($${SRC_ROOT}/src/*.h)
-
-macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/libs/hunspell/hunspell.pro
+++ b/src/libs/hunspell/hunspell.pro
@@ -34,5 +34,3 @@ OTHER_FILES += \
     $${SRC_ROOT}/license.myspell \
     $${SRC_ROOT}/license.hunspell \
     $${SRC_ROOT}/src/hunspell/utf_info.cxx
-
-macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/libs/hunspell/hunspell.pro
+++ b/src/libs/hunspell/hunspell.pro
@@ -7,14 +7,12 @@
 TARGET = hunspell
 TEMPLATE = lib
 
-QT -= core gui
+CONFIG -= qt
 
 DEFINES += HUNSPELL_LIBRARY
 DEFINES += BUILDING_LIBHUNSPELL
 
 CONFIG += precompile_header
-
-OBJECTS_DIR += temp
 
 SRC_ROOT = $$PWD/../../../3rdparty/hunspell.git
 
@@ -36,3 +34,5 @@ OTHER_FILES += \
     $${SRC_ROOT}/license.myspell \
     $${SRC_ROOT}/license.hunspell \
     $${SRC_ROOT}/src/hunspell/utf_info.cxx
+
+macx:QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/src/test/integration/integration.pro
+++ b/src/test/integration/integration.pro
@@ -10,7 +10,7 @@ include(../../global.pri)
 
 QT += testlib
 QT += gui
-lessThan(QT_VERSION, 5.6) {
+qtHaveModule(webkitwidgets) {
     QT += webkitwidgets
     DEFINES += WITH_QTWEBENGINE=0
 } else {
@@ -19,6 +19,7 @@ lessThan(QT_VERSION, 5.6) {
 }
 
 CONFIG += console testcase
+CONFIG -= app_bundle
 CONFIG += c++11
 
 SOURCES += \

--- a/src/test/unit/unit.pro
+++ b/src/test/unit/unit.pro
@@ -8,6 +8,7 @@ QT += testlib
 
 TARGET = unittest
 CONFIG += console testcase
+CONFIG -= app_bundle
 CONFIG += c++11
 
 SOURCES += \


### PR DESCRIPTION
1. replaced `QT -= core gui` with `CONFIG -= qt` in project files for 3rd party libraries
2. better support for macOS build:
 - added `CONFIG -= app_bundle` to test projects to build "true" console app
 - added macOS specific linker options for 3rd party libraries, without them deployed app even can't be run (libraries are not found, even they are in app bundle)
3. replaced Qt version check with WebKit module existence check, it is not a problem to build QtWebKit with Qt >5.5 (maybe much easier to build it with Qt, what I done).

I successfully compiled Qt 5.6.3 (branch 5.6 from git) with WebKit for macOS (Xcode 7) and Windows (MSVC 2015 x64), this was not to hard, especially on macOS. Qt 5.6 was chosen because it has very good support for HiDPI (Retina) displays unlike any previous version and it has less number of modules and external dependencies comparing to newer versions. I used git version because only it has required patch to work correctly on newer macOS (10.12, Sierra). This patch already included only in Qt 5.8.

Thank you for merging my previous pull requests. More changes related to macOS (my primary OS) and HiDPI (Retina) displays support are coming :) .
Special thanks for restructuring and putting in order all external libraries. You made build process to easy, no matter on each platform. I couldn't build this app on Windows before, especially with Visual Studio.