### PR TITLE
fixed build with hoedown on macOS

### DIFF
--- a/src/app-static/app-static.pro
+++ b/src/app-static/app-static.pro
@@ -104,5 +104,5 @@ with_hoedown {
     SOURCES += converter/hoedown_markdown_converter.cpp
     HEADERS += converter/hoedown_markdown_converter.h
 
-    win32:INCLUDEPATH += $$PWD/../../3rdparty/hoedown.git
+    win32|macx:INCLUDEPATH += $$PWD/../../3rdparty/hoedown.git
 }

--- a/src/app-static/converter/hoedown_markdown_converter.cpp
+++ b/src/app-static/converter/hoedown_markdown_converter.cpp
@@ -31,7 +31,7 @@
  */
 
 extern "C" {
-#ifdef Q_OS_WIN
+#if defined(_WIN32) || defined(__APPLE__)
 #include <src/html.h>
 #include <src/markdown.h>
 #else

--- a/src/libs/libs.pro
+++ b/src/libs/libs.pro
@@ -7,7 +7,7 @@ SUBDIRS += \
     peg-markdown-highlight \
     pmh-adapter
 
-win32 {
+win32|macx {
     with_hoedown {
         message("3rdparty: Build hoedown markdown converter library")
         DEFINES += ENABLE_HOEDOWN


### PR DESCRIPTION
- allowed build with hoedown on macOS
- used hoedown lib from sub-repo on macOS
- used "pure" platform specific defines instead of "Qt equivalents", Qt platform defines defined in 'QtGlobal' include and doesn't work in pure C/C++ code without this include