### PR TITLE
fixed few warnings

### DIFF
--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -164,7 +164,7 @@ private:
     ThemeCollection *_theme_collection;
     Theme _current_theme { "Default", "Default", "Default", "Default" };
     QString _file_name;
-    float _split_factor;
+    qreal _split_factor;
     bool _right_view_collapsed;
 };
 

--- a/src/global.pri
+++ b/src/global.pri
@@ -18,6 +18,6 @@ mac: contains(TEMPLATE, lib): !contains(CONFIG, staticlib) {
     QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
 }
 mac: contains(TEMPLATE, app) {
-    QMAKE_LFLAGS += -Wl,-rpath,@executable_path -Wl,-rpath,@executable_path/../Frameworks
+    QMAKE_LFLAGS += -Wl,-rpath,@executable_path/../Frameworks
     QMAKE_LFLAGS_RPATH =
 }


### PR DESCRIPTION
fixed few warnings on Windows:
```
..\..\src\app\mainwindow.cpp(501): warning C4305: '=': truncation from 'double' to 'float'
..\..\src\app\mainwindow.cpp(503): warning C4305: '=': truncation from 'double' to 'float'
```
fixed error messages (build did NOT fail with them!) on macOS:
```
ERROR: Unexpected prefix "@executable_path"
ERROR: Unexpected prefix "@executable_path"
ERROR: Unexpected prefix "@executable_path"
```